### PR TITLE
Update cloudDriver.json

### DIFF
--- a/.homeycompose/drivers/templates/cloudDriver.json
+++ b/.homeycompose/drivers/templates/cloudDriver.json
@@ -50,7 +50,7 @@
 				},
 				"passwordLabel": {
 					"en": "Secret Key",
-					"nl": "Geheime sleutel",
+					"nl": "Secret Key",
 					"da": "Hemmelig nøgle",
 					"de": "Geheimer Schlüssel",
 					"es": "Clave secreta",
@@ -64,7 +64,7 @@
 				},
 				"passwordPlaceholder": {
 					"en": "Secret Key obtained for the YoLink app",
-					"nl": "Geheime sleutel voor de YoLink-app",
+					"nl": "Secret Key uit de YoLink-app",
 					"da": "Hemmelig nøgle til YoLink-appen",
 					"de": "Geheimer Schlüssel für die YoLink-App",
 					"es": "Clave secreta obtenida para la aplicación YoLink",


### PR DESCRIPTION
Changes the Dutch translation for "Secret Key" back to "Secret Key", since this is how it is called in the Android YoLink app (which isn't translated to Dutch). Don't know how this is on iOS or if the Android/iOS app is translated to other languages or that it is English-only. Then it might be wise to use "Secret Key" everywhere.