### PR TITLE
Improve water depth sensor: formula-based depth, Homey-side alarms, metres display

### DIFF
--- a/.homeycompose/capabilities/measure_water_depth.json
+++ b/.homeycompose/capabilities/measure_water_depth.json
@@ -13,10 +13,10 @@
 		"pl": "Głębokość wody",
 		"ko": "수심"
     },
-	"units": "%",
+	"units": "m",
 	"insights": true,
 	"chartType": "stepLine",
-	"decimals": 1,
+	"decimals": 2,
     "getable": true,
     "setable": false,
 	"uiComponent": "sensor",

--- a/app.json
+++ b/app.json
@@ -3496,37 +3496,95 @@
           "value": "us"
         },
         {
+          "id": "sensorRange",
+          "type": "dropdown",
+          "label": {
+            "en": "Length of sensor cable 5m or 10m"
+          },
+          "hint": {
+            "en": "Select the cable length of your YoLink water depth sensor. 5m uses a range factor of 0.5, 10m uses 1.0."
+          },
+          "values": [
+            {
+              "id": "0.5",
+              "label": {
+                "en": "5m"
+              }
+            },
+            {
+              "id": "1.0",
+              "label": {
+                "en": "10m"
+              }
+            }
+          ],
+          "value": "0.5"
+        },
+        {
+          "id": "liquidDensity",
+          "type": "number",
+          "label": {
+            "en": "Liquid density"
+          },
+          "hint": {
+            "en": "Density of the liquid relative to water. Use 1.0 for water."
+          },
+          "value": 1
+        },
+        {
           "id": "tankDepth",
           "type": "number",
           "label": {
-            "en": "Tank depth (cm)",
-            "nl": "Tankdiepte (cm)",
-            "da": "Tankdybde (cm)",
-            "de": "Tanktiefe (cm)",
-            "es": "Profundidad del tanque (cm)",
-            "fr": "Profondeur du réservoir (cm)",
-            "it": "Profondità del serbatoio (cm)",
-            "no": "Tankdybde (cm)",
-            "sv": "Tankdjup (cm)",
-            "pl": "Głębokość zbiornika (cm)",
-            "ru": "Глубина резервуара (см)",
-            "ko": "탱크 깊이 (cm)"
+            "en": "Tank depth (m)",
+            "nl": "Tankdiepte (m)",
+            "da": "Tankdybde (m)",
+            "de": "Tanktiefe (m)",
+            "es": "Profundidad del tanque (m)",
+            "fr": "Profondeur du réservoir (m)",
+            "it": "Profondità del serbatoio (m)",
+            "no": "Tankdybde (m)",
+            "sv": "Tankdjup (m)",
+            "pl": "Głębokość zbiornika (m)",
+            "ru": "Глубина резервуара (м)",
+            "ko": "탱크 깊이 (m)"
           },
           "hint": {
-            "en": "Set the total depth of your tank in centimeters.",
-            "nl": "Stel de totale diepte van uw tank in centimeters in.",
-            "da": "Angiv den samlede dybde af din tank i centimeter.",
-            "de": "Stellen Sie die Gesamttiefe Ihres Tanks in Zentimetern ein.",
-            "es": "Configure la profundidad total de su tanque en centímetros.",
-            "fr": "Définissez la profondeur totale de votre réservoir en centimètres.",
-            "it": "Imposta la profondità totale del serbatoio in centimetri.",
-            "no": "Angi total dybde på tanken i centimeter.",
-            "sv": "Ange tankens totala djup i centimeter.",
-            "pl": "Ustaw całkowitą głębokość zbiornika w centymetrach.",
-            "ru": "Укажите общую глубину резервуара в сантиметрах.",
-            "ko": "탱크의 전체 깊이를 센티미터로 설정하세요."
+            "en": "Total depth of your tank in meters.",
+            "nl": "Totale diepte van uw tank in meters.",
+            "da": "Din tanks samlede dybde i meter.",
+            "de": "Gesamttiefe Ihres Tanks in Metern.",
+            "es": "Profundidad total de su tanque en metros.",
+            "fr": "Profondeur totale de votre réservoir en mètres.",
+            "it": "Profondità totale del serbatoio in metri.",
+            "no": "Total dybde på tanken i meter.",
+            "sv": "Tankens totala djup i meter.",
+            "pl": "Całkowita głębokość zbiornika w metrach.",
+            "ru": "Общая глубина резервуара в метрах.",
+            "ko": "탱크의 전체 깊이(미터)."
           },
-          "value": 200
+          "value": 2
+        },
+        {
+          "id": "lowDepthThreshold",
+          "type": "number",
+          "label": {
+            "en": "Low depth alarm threshold (meters)"
+          },
+          "hint": {
+            "en": "Trigger a low water alarm in Homey when depth falls at or below this value (meters). Set to 0 to use YoLink's own alarm instead."
+          },
+          "value": 0
+        },
+        {
+          "id": "highDepthThreshold",
+          "type": "number",
+          "label": {
+            "en": "High depth alarm threshold (meters)"
+          },
+          "hint": {
+            "en": "Trigger a high water alarm in Homey when depth reaches or exceeds this value (meters). Set to 0 to use YoLink's own alarm instead."
+          },
+          "value": 0
         }
       ]
     },
@@ -4041,10 +4099,10 @@
         "pl": "Głębokość wody",
         "ko": "수심"
       },
-      "units": "%",
+      "units": "m",
       "insights": true,
       "chartType": "stepLine",
-      "decimals": 1,
+      "decimals": 2,
       "getable": true,
       "setable": false,
       "uiComponent": "sensor",

--- a/drivers/water-depth-sensor/device.js
+++ b/drivers/water-depth-sensor/device.js
@@ -37,7 +37,34 @@ module.exports = class WaterDepthSensorDevice extends Homey.Device
 			const tankDepth = Number(newSettings.tankDepth);
 			if (!Number.isFinite(tankDepth) || tankDepth <= 0)
 			{
-				throw new Error('Tank depth must be a positive number.');
+				throw new Error('Tank depth must be a positive number in meters.');
+			}
+		}
+
+		if (changedKeys.includes('liquidDensity'))
+		{
+			const density = Number(newSettings.liquidDensity);
+			if (!Number.isFinite(density) || density <= 0)
+			{
+				throw new Error('Liquid density must be a positive number (use 1.0 for water).');
+			}
+		}
+
+		if (changedKeys.includes('lowDepthThreshold'))
+		{
+			const low = Number(newSettings.lowDepthThreshold);
+			if (!Number.isFinite(low) || low < 0)
+			{
+				throw new Error('Low depth threshold must be 0 or a positive number in meters.');
+			}
+		}
+
+		if (changedKeys.includes('highDepthThreshold'))
+		{
+			const high = Number(newSettings.highDepthThreshold);
+			if (!Number.isFinite(high) || high < 0)
+			{
+				throw new Error('High depth threshold must be 0 or a positive number in meters.');
 			}
 		}
 
@@ -66,7 +93,6 @@ module.exports = class WaterDepthSensorDevice extends Homey.Device
 	{
 		const data = await this.getData();
 		const settings = await this.getSettings();
-		const tankMaxDepth = Number(settings.tankDepth);
 		const state = await this.driver.getState(data, settings);
 		this.unsetWarning().catch(this.error);
 		if (!state || !state.data || !state.data.online || state.data.online !== true)
@@ -82,10 +108,10 @@ module.exports = class WaterDepthSensorDevice extends Homey.Device
 		}
 		this.setAvailable().catch(this.error);
 
-		this.setCapabilityValue('alarm_water.low', state.data.state.alarm.lowAlarm).catch(this.error);
-		this.setCapabilityValue('alarm_water.high', state.data.state.alarm.highAlarm).catch(this.error);
-		const actualPercentage = this.calculateWaterDepthPercentage(state.data.state.waterDepth, tankMaxDepth);
-		this.setCapabilityValue('measure_water_depth', actualPercentage).catch(this.error);
+		const depthInCm = this.calculateDepthInCm(state.data.state.waterDepth, settings.sensorRange, settings.liquidDensity);
+		const displayValue = this.calculateDisplayValue(depthInCm);
+		this.setCapabilityValue('measure_water_depth', displayValue).catch(this.error);
+		this.setWaterAlarms(depthInCm, state.data.state.alarm.lowAlarm, state.data.state.alarm.highAlarm, settings);
 
 		// The returned battery is a string with a level between 0 and 4, so convert to 0 to 1
 		if (state.data.state.battery)
@@ -100,7 +126,6 @@ module.exports = class WaterDepthSensorDevice extends Homey.Device
 	async processMQTTMessage(mqttMessage)
 	{
 		const settings = await this.getSettings();
-		const tankMaxDepth = Number(settings.tankDepth);
 		let mqttData;
 		let deviceId;
 		// Check if the event field is present so we know what type of message this is
@@ -132,30 +157,62 @@ module.exports = class WaterDepthSensorDevice extends Homey.Device
 
 		if (mqttData.state)
 		{
-			this.setCapabilityValue('alarm_water.low', mqttData.state.alarm.lowAlarm).catch(this.error);
-			this.setCapabilityValue('alarm_water.high', mqttData.state.alarm.highAlarm).catch(this.error);
-			const actualPercentage = this.calculateWaterDepthPercentage(mqttData.state.waterDepth, tankMaxDepth);
-			this.setCapabilityValue('measure_water_depth', actualPercentage).catch(this.error);
+			const depthInCm = this.calculateDepthInCm(mqttData.state.waterDepth, settings.sensorRange, settings.liquidDensity);
+			const displayValue = this.calculateDisplayValue(depthInCm);
+			this.setCapabilityValue('measure_water_depth', displayValue).catch(this.error);
+			this.setWaterAlarms(depthInCm, mqttData.state.alarm.lowAlarm, mqttData.state.alarm.highAlarm, settings);
 		}
 
 		return true;
 	}
 
-	calculateWaterDepthPercentage(rawWaterDepth, tankMaxDepth)
+	// Returns actual depth in cm: formula = (sensorRange * rawWaterDepth) / liquidDensity
+	// sensorRange: 0.5 for 5m cable, 1.0 for 10m cable
+	// rawWaterDepth: integer value from YoLink API
+	// liquidDensity: 1.0 for water
+	calculateDepthInCm(rawWaterDepth, sensorRange, liquidDensity)
 	{
-		const rawDepth = Number(rawWaterDepth);
-		if (!Number.isFinite(rawDepth))
+		const raw = Number(rawWaterDepth);
+		const range = Number(sensorRange);
+		const density = Number(liquidDensity);
+
+		if (!Number.isFinite(raw) || raw < 0)
 		{
 			return 0;
 		}
 
-		if (!Number.isFinite(tankMaxDepth) || tankMaxDepth <= 0)
+		// If sensor cable / density not yet configured, return raw value in metres as a safe fallback
+		if (!Number.isFinite(range) || range <= 0 || !Number.isFinite(density) || density <= 0)
 		{
-			return rawDepth;
+			return raw / 100;
 		}
 
-		const currentDepth = rawDepth / 10;
+		return (range * raw) / density;
+	}
 
-		return (currentDepth / tankMaxDepth) * 100;
+	// Returns depth in metres for display on the device card
+	calculateDisplayValue(depthInCm)
+	{
+		return depthInCm / 100;
+	}
+
+	// Evaluates alarms against Homey-side metre thresholds.
+	// Falls back to YoLink's own alarm flags when thresholds are left at 0.
+	setWaterAlarms(depthInCm, yolinkLowAlarm, yolinkHighAlarm, settings)
+	{
+		const depthInMeters = depthInCm / 100;
+		const lowThreshold = Number(settings.lowDepthThreshold);
+		const highThreshold = Number(settings.highDepthThreshold);
+
+		const lowAlarm = (Number.isFinite(lowThreshold) && lowThreshold > 0)
+			? depthInMeters <= lowThreshold
+			: yolinkLowAlarm;
+
+		const highAlarm = (Number.isFinite(highThreshold) && highThreshold > 0)
+			? depthInMeters >= highThreshold
+			: yolinkHighAlarm;
+
+		this.setCapabilityValue('alarm_water.low', lowAlarm).catch(this.error);
+		this.setCapabilityValue('alarm_water.high', highAlarm).catch(this.error);
 	}
 };

--- a/drivers/water-depth-sensor/driver.settings.compose.json
+++ b/drivers/water-depth-sensor/driver.settings.compose.json
@@ -69,36 +69,94 @@
 		"value": "us"
 	},
 	{
+		"id": "sensorRange",
+		"type": "dropdown",
+		"label": {
+			"en": "Length of sensor cable 5m or 10m"
+		},
+		"hint": {
+			"en": "Select the cable length of your YoLink water depth sensor. 5m uses a range factor of 0.5, 10m uses 1.0."
+		},
+		"values": [
+			{
+				"id": "0.5",
+				"label": {
+					"en": "5m"
+				}
+			},
+			{
+				"id": "1.0",
+				"label": {
+					"en": "10m"
+				}
+			}
+		],
+		"value": "0.5"
+	},
+	{
+		"id": "liquidDensity",
+		"type": "number",
+		"label": {
+			"en": "Liquid density"
+		},
+		"hint": {
+			"en": "Density of the liquid relative to water. Use 1.0 for water."
+		},
+		"value": 1.0
+	},
+	{
 		"id": "tankDepth",
 		"type": "number",
 		"label": {
-			"en": "Tank depth (cm)",
-			"nl": "Tankdiepte (cm)",
-			"da": "Tankdybde (cm)",
-			"de": "Tanktiefe (cm)",
-			"es": "Profundidad del tanque (cm)",
-			"fr": "Profondeur du réservoir (cm)",
-			"it": "Profondità del serbatoio (cm)",
-			"no": "Tankdybde (cm)",
-			"sv": "Tankdjup (cm)",
-			"pl": "Głębokość zbiornika (cm)",
-			"ru": "Глубина резервуара (см)",
-			"ko": "탱크 깊이 (cm)"
+			"en": "Tank depth (m)",
+			"nl": "Tankdiepte (m)",
+			"da": "Tankdybde (m)",
+			"de": "Tanktiefe (m)",
+			"es": "Profundidad del tanque (m)",
+			"fr": "Profondeur du réservoir (m)",
+			"it": "Profondità del serbatoio (m)",
+			"no": "Tankdybde (m)",
+			"sv": "Tankdjup (m)",
+			"pl": "Głębokość zbiornika (m)",
+			"ru": "Глубина резервуара (м)",
+			"ko": "탱크 깊이 (m)"
 		},
 		"hint": {
-			"en": "Set the total depth of your tank in centimeters.",
-			"nl": "Stel de totale diepte van uw tank in centimeters in.",
-			"da": "Angiv den samlede dybde af din tank i centimeter.",
-			"de": "Stellen Sie die Gesamttiefe Ihres Tanks in Zentimetern ein.",
-			"es": "Configure la profundidad total de su tanque en centímetros.",
-			"fr": "Définissez la profondeur totale de votre réservoir en centimètres.",
-			"it": "Imposta la profondità totale del serbatoio in centimetri.",
-			"no": "Angi total dybde på tanken i centimeter.",
-			"sv": "Ange tankens totala djup i centimeter.",
-			"pl": "Ustaw całkowitą głębokość zbiornika w centymetrach.",
-			"ru": "Укажите общую глубину резервуара в сантиметрах.",
-			"ko": "탱크의 전체 깊이를 센티미터로 설정하세요."
+			"en": "Total depth of your tank in meters.",
+			"nl": "Totale diepte van uw tank in meters.",
+			"da": "Din tanks samlede dybde i meter.",
+			"de": "Gesamttiefe Ihres Tanks in Metern.",
+			"es": "Profundidad total de su tanque en metros.",
+			"fr": "Profondeur totale de votre réservoir en mètres.",
+			"it": "Profondità totale del serbatoio in metri.",
+			"no": "Total dybde på tanken i meter.",
+			"sv": "Tankens totala djup i meter.",
+			"pl": "Całkowita głębokość zbiornika w metrach.",
+			"ru": "Общая глубина резервуара в метрах.",
+			"ko": "탱크의 전체 깊이(미터)."
 		},
-		"value": 200
+		"value": 2.0
+	},
+	{
+		"id": "lowDepthThreshold",
+		"type": "number",
+		"label": {
+			"en": "Low depth alarm threshold (meters)"
+		},
+		"hint": {
+			"en": "Trigger a low water alarm in Homey when depth falls at or below this value (meters). Set to 0 to use YoLink's own alarm instead."
+		},
+		"value": 0
+	},
+	{
+		"id": "highDepthThreshold",
+		"type": "number",
+		"label": {
+			"en": "High depth alarm threshold (meters)"
+		},
+		"hint": {
+			"en": "Trigger a high water alarm in Homey when depth reaches or exceeds this value (meters). Set to 0 to use YoLink's own alarm instead."
+		},
+		"value": 0
 	}
 ]


### PR DESCRIPTION
## Summary

- **Physical depth formula** — replaces the naive `rawDepth / 10` conversion with `depthInCm = (sensorRange x rawWaterDepth) / liquidDensity`, where `sensorRange` is `0.5` for the 5m cable and `1.0` for the 10m cable
- **Homey-side alarm thresholds** — new low/high depth threshold settings (in metres) evaluated locally in Homey, independent of YoLink's own alarm flags; falls back to YoLink flags when thresholds are left at `0`
- **Display in metres** — `measure_water_depth` capability unit changed from `%` to `m`; device card always shows actual depth in metres

## New device settings

| Setting | Type | Default | Notes |
|---|---|---|---|
| Length of sensor cable | Dropdown | 5m | 5m = factor 0.5, 10m = factor 1.0 |
| Liquid density | Number | 1.0 | 1.0 for water |
| Tank depth | Number | 2.0 m | Was 200 cm, now in metres |
| Low depth alarm threshold | Number | 0 m | 0 = use YoLink alarm |
| High depth alarm threshold | Number | 0 m | 0 = use YoLink alarm |

## Test plan

- [ ] Add a new water depth sensor device and confirm all five new settings appear
- [ ] Confirm device card shows depth in metres (e.g. `0.93 m`)
- [ ] Set low/high thresholds and verify Homey alarms fire independently of YoLink app settings
- [ ] Set thresholds to `0` and verify fallback to YoLink alarm flags works
- [ ] Test with both 5m and 10m cable range settings
